### PR TITLE
Adding count to each filter item

### DIFF
--- a/components/Filter.js
+++ b/components/Filter.js
@@ -19,6 +19,12 @@ export default function Filter({
   handleCloseFilter,
   categoryName,
 }) {
+
+  let countItems = {};
+  items.forEach(item => {
+    countItems[item.label] = countItems[item.label] + 1 || 1
+  })
+
   return (
     <motion.div
       variants={sidebarAnimation}
@@ -45,24 +51,31 @@ export default function Filter({
           <CloseSVG />
         </a>
         <h3>
-          {categoryName.charAt(0).charAt(0).toUpperCase() +
-            categoryName.slice(1)}
+          FILTER
         </h3>
 
-        {items.sort((a, b)=>{
+        {items.sort((a, b) => {
           if (a.label > b.label) return 1;
           if (a.label < b.label) return -1;
           return 0;
-        }).map((item, i) => (
-          <FilterItem
-            key={`${item.label}-${i}`}
-            label={item.label}
-            active={item.active}
-            onClick={() => {
-              handleFilterClick(item);
-            }}
-          />
-        ))}
+        }).filter((curr, index, self) => (
+          index === self.findIndex((t) => (
+            t.label === curr.label
+          ))
+        ))
+          .map((item, i) => {
+            return (
+              <FilterItem
+                key={`${item.label}-${i}`}
+                label={item.label}
+                active={item.active}
+                count={countItems[item.label]}
+                onClick={() => {
+                  handleFilterClick(item);
+                }}
+              />
+            )
+          })}
       </div>
       <style jsx>{`
         .sidebar {
@@ -83,24 +96,32 @@ export default function Filter({
 
         h3 {
           margin-top: 4rem;
-          font-weight: 500;
+          font-size: 0.9rem;
+          letter-spacing: 0.075rem;
+          font-weight: 600;
+          text-transform: uppercase;
         }
       `}</style>
     </motion.div>
   );
 }
 
-function FilterItem({ label, active, onClick }) {
+function FilterItem({ label, active, onClick, count }) {
   return (
     <div className="filterItem" onClick={onClick}>
-      {label}
+      <div>
+        {label}
+        <span className="filterItem__count">
+          ({count})
+        </span>
+      </div>
       <div className={`check ${active ? "active" : ""}`}>
         <CheckSVG />
       </div>
       <style jsx>{`
         .filterItem {
           cursor: pointer;
-          font-size: 1.7rem;
+          font-size: 1.2rem;
           display: flex;
           justify-content: space-between;
           align-items: center;
@@ -108,6 +129,11 @@ function FilterItem({ label, active, onClick }) {
         }
 
         .filterItem:hover {
+          color: var(--color-link);
+        }
+        .filterItem__count {
+          font-size: 0.75em;
+          margin-left: 0.5rem;
           color: var(--color-link);
         }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -17,21 +17,13 @@ export async function getStaticProps() {
   const res = await fetch(`${origin}/api/technologists`);
   const technologists = await res.json();
 
-  let uniqueRole = new Set();
-  technologists.map((d) => uniqueRole.add(d.role));
-
-  let uniqueLocation = new Set();
-  technologists.map((d) => uniqueLocation.add(d.location));
-
-  let roles = Array.from(uniqueRole).map((e) => {
-    return { label: e, active: false, category: "role" };
+  let roles = technologists.map((technologist) => {
+    return { label: technologist.role, active: false, category: "role" };
   });
 
-  let locations = Array.from(uniqueLocation)
-    .sort()
-    .map((e) => {
-      return { label: e, active: false, category: "location" };
-    });
+  let locations = technologists.map((technologist) => {
+    return { label: technologist.location, active: false, category: "location" };
+  });
 
   let filters = roles.concat(locations);
 
@@ -178,11 +170,8 @@ function Content({ technologists, handleOpenFilter, className, onClick }) {
 
   return (
     <div className={className} onClick={onClick}>
-         <HitLogo/>
+      <HitLogo />
       <Nav />
-
-   
-
       <Title className="title m0 p0" text="Hawaiians*in&nbsp;Technology" />
       <motion.div
         initial={{ opacity: 0 }}

--- a/pages/index.js
+++ b/pages/index.js
@@ -200,7 +200,7 @@ function Content({ technologists, handleOpenFilter, className, onClick }) {
                   e.preventDefault();
                 }}
               >
-                Role <FilterSVG />
+                Role / Background <FilterSVG />
               </td>
               <td className="thsize-link"></td>
             </tr>


### PR DESCRIPTION
**Adds a count to each filter item, e.g. Location or Role.** This is an attempt at making the filters slightly more _useful_, by grouping like items and showing their count. The end goal is that a user could **seek kanaka by a Location or Role of interest**.

![image](https://user-images.githubusercontent.com/5141111/126453592-ff07451a-4ff4-4c0f-a1eb-2da75902c919.png)

This opens up a broader question on how we want to approach that column going further.
- This approach asserts that having **broader, common filters** is more useful than specific and one-off. I worry that if we continue to distinguish individuals with one-off titles, we run the risk of making the filter essentially useless (i.e. any specific filter only has one person lol).
- I admittedly started to sneak in a few changes on the spreadsheet side to make this function better. 😬
- I know we discussed this briefly but I want to re-spur the conversation — should we transition that column to be Focus/Background instead of one-off job titles?
- I remember the issue is that we would sort of be speaking on behalf of the listees. I am personally comfortable with this risk if we do it in good faith, based on what their careers have been focused on in aggregate. We can reach out to the current list and adjust our intake form to accommodate for this new format.