### PR TITLE
Add Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ yarn dev
 
 In your browser, open `localhost:3000`.
 
+#### TIP
+
+If the airtable API key is missing, you can simulate it by changing this line in `index.js`
+```javascript
+import { fetchTechnologists } from "../lib/api";
+```
+to
+```javascript
+import { fetchTechnologists } from "../lib/stubApi";
+```
+
 ### Deploy at vercel
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https%3A%2F%2Fgithub.com%2Fhawaiians%2Fhawaiiansintech)

--- a/lib/stubApi.js
+++ b/lib/stubApi.js
@@ -1,0 +1,63 @@
+/**
+ * Stubbed function to simulate fetching technologists
+ * without connecting to airtable.
+ * 
+ * @returns stubbed values
+ */
+export async function fetchTechnologists() {
+  return [
+    {
+      name: "Andrew Taeoalii",
+      location: "Hawaii",
+      region: "USA",
+      role: "Software Engineer",
+      link: "https://linkedin.com/in/andrewtaeoalii"
+    },
+    {
+      name: "Emmit Kamakani Parubrub",
+      location: "San Francisco",
+      region: "California",
+      role: "Software Engineer",
+      link: "https://linkedin.com/in/emmitparubrub"
+    },
+    {
+      name: "Taylor Ho",
+      location: "San Francisco",
+      region: "California",
+      role: "UX Designer",
+      link: "https://linkedin.com/in/taylorho"
+    },
+    {
+      name: "Tianna Johnson",
+      location: "San Francisco",
+      region: "California",
+      role: "Talent Acquisition",
+      link: "https://linkedin.com/in/tiannajohnson"
+    }
+  ]
+}
+
+/**
+ * Stubbed function to fetch roles without connecting to airtable.
+ * 
+ * @returns stubbed roles
+ */
+export async function fetchRoles() {
+  return [
+    {
+      name: "Software Engineer",
+      members: ["Andrew Taeoalii", "Emmit Kamakani Parubrub"],
+      count: 2
+    },
+    {
+      name: "Talent Acquisition",
+      members: ["Tianna Johnson"],
+      count: 1
+    },
+    {
+      name: "UX Designer",
+      members: ["Taylor Ho"],
+      count: 1
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "^11.0.1",
     "next-absolute-url": "^1.2.2",
     "react": "16.14",
-    "react-dom": "16.13.1"
+    "react-dom": "16.13.1",
+    "react-ga": "^3.3.0"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,26 @@
 import "../assets/styles/modernism.css";
 import { AnimatePresence } from "framer-motion";
+import Script from "next/script";
 
 function App({ Component, pageProps }) {
   return (
-    <AnimatePresence>
-      <Component {...pageProps} />
-    </AnimatePresence>
+      <AnimatePresence>
+      {/* Adds google analytics to all pages */}
+      <Script
+        strategy='lazyOnload'
+        src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GA_TAG_ID}`} />
+      <Script strategy='lazyOnload'>
+        {
+          `
+          window.dataLayer = window.dataLayer || [];
+          function gtag() {dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${process.env.GA_TAG_ID}');
+          `
+        }
+      </Script>
+        <Component {...pageProps} />
+      </AnimatePresence>
   );
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,7 +10,7 @@ import FilterSVG from "../components/Icons/FilterSVG.js";
 import HitLogo from "../components/HitLogo.js";
 
 export default function Home({ technologists, filters }) {
-  const [isReady, setIsReady] = useState(false);
+  const [isReady] = useState(false);
   const [technologistsList, setTechnologistsList] = useState(null);
   const [filterIsOpen, setFilterIsOpen] = useState(false);
   const [filterList, setFilterList] = useState(filters);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,6 +1649,11 @@ react-dom@16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-ga@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.0.tgz#c91f407198adcb3b49e2bc5c12b3fe460039b3ca"
+  integrity sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==
+
 react-is@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"


### PR DESCRIPTION
Setup google analytics to track standard events/metrics associated with site visits.

- Add GA script to app.js
- Create stub API for easy testing without airtable API keys
TODO: Actual GA account needs to be setup for the project.

- [x] - tested locally
- [x] - setup personal GA account
- [x] - captured standard site visit, page, event stats

![Screen Shot 2022-02-19 at 1 24 06 PM](https://user-images.githubusercontent.com/1114596/154823132-e10c4c26-45cd-400c-b57f-fae15f6d8b44.png)
![Screen Shot 2022-02-19 at 1 23 56 PM](https://user-images.githubusercontent.com/1114596/154823133-f4344169-14d4-4c4d-9e30-9e80e12e058d.png)
![Screen Shot 2022-02-19 at 1 24 13 PM](https://user-images.githubusercontent.com/1114596/154823129-7d9fc4fe-5244-4629-a55f-3afcc9741183.png)