### PR TITLE
Create Stub API for Local Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ yarn dev
 
 In your browser, open `localhost:3000`.
 
+#### TIP
+
+If the airtable API key is missing, you can simulate it by changing this line in `index.js`
+```javascript
+import { fetchTechnologists } from "../lib/api";
+```
+to
+```javascript
+import { fetchTechnologists } from "../lib/stubApi";
+```
+
 ### Deploy at vercel
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https%3A%2F%2Fgithub.com%2Fhawaiians%2Fhawaiiansintech)

--- a/lib/stubApi.js
+++ b/lib/stubApi.js
@@ -1,0 +1,63 @@
+/**
+ * Stubbed function to simulate fetching technologists
+ * without connecting to airtable.
+ * 
+ * @returns stubbed values
+ */
+export async function fetchTechnologists() {
+  return [
+    {
+      name: "Andrew Taeoalii",
+      location: "Hawaii",
+      region: "USA",
+      role: "Software Engineer",
+      link: "https://linkedin.com/in/andrewtaeoalii"
+    },
+    {
+      name: "Emmit Kamakani Parubrub",
+      location: "San Francisco",
+      region: "California",
+      role: "Software Engineer",
+      link: "https://linkedin.com/in/emmitparubrub"
+    },
+    {
+      name: "Taylor Ho",
+      location: "San Francisco",
+      region: "California",
+      role: "UX Designer",
+      link: "https://linkedin.com/in/taylorho"
+    },
+    {
+      name: "Tianna Johnson",
+      location: "San Francisco",
+      region: "California",
+      role: "Talent Acquisition",
+      link: "https://linkedin.com/in/tiannajohnson"
+    }
+  ]
+}
+
+/**
+ * Stubbed function to fetch roles without connecting to airtable.
+ * 
+ * @returns stubbed roles
+ */
+export async function fetchRoles() {
+  return [
+    {
+      name: "Software Engineer",
+      members: ["Andrew Taeoalii", "Emmit Kamakani Parubrub"],
+      count: 2
+    },
+    {
+      name: "Talent Acquisition",
+      members: ["Tianna Johnson"],
+      count: 1
+    },
+    {
+      name: "UX Designer",
+      members: ["Taylor Ho"],
+      count: 1
+    }
+  ]
+}


### PR DESCRIPTION
Initial setup requires proper environment variable setup. Adding a stub API to allow for staging local instances without connecting to external APIs.

- [x] - tested locally with stub API
- [x] -  minor note added to README.md to help first time contributors.

![Screen Shot 2022-02-19 at 7 06 12 PM](https://user-images.githubusercontent.com/1114596/154829309-5af5e7f1-f73d-43e8-a30d-2e1e474fddc1.png)
.