### PR TITLE
Better <FocusPicker /> for smaller screens

### DIFF
--- a/components/BannerAlert.tsx
+++ b/components/BannerAlert.tsx
@@ -12,7 +12,6 @@ interface BannerAlertProps {
 
 export default function BannerAlert({
   children,
-  link,
   onClose,
   tag,
 }: BannerAlertProps) {
@@ -42,17 +41,7 @@ export default function BannerAlert({
           border-radius: ${theme.borderRadius.sm};
           padding: 1rem ${onClose ? "3rem" : "1rem"} 1rem 1rem;
           color: ${theme.color.brand.base};
-          font-weight: 500;
-        }
-        .banner-alert__links {
-          display: flex;
-        }
-        .banner-alert__link {
-          font-weight: 600;
-          font-size: 0.875rem;
-          margin-top: 0.5rem;
-          color: ${theme.color.brand.alt};
-          cursor: pointer;
+          font-weight: 400;
         }
         .banner-alert__close {
           ${cssHelperButtonReset}

--- a/components/FocusPicker.tsx
+++ b/components/FocusPicker.tsx
@@ -1,5 +1,6 @@
 import { Focus } from "@/lib/api";
 import { useWindowWidth } from "@/lib/hooks";
+import Link from "next/link";
 import { useLayoutEffect, useRef, useState } from "react";
 import theme from "styles/theme";
 import BannerAlert from "./BannerAlert";
@@ -102,9 +103,10 @@ export default function FocusPicker({
             }}
           >
             <BannerAlert tag="ALMOST PAU">
-              <strong>New filter functionality coming soon!</strong> Recently
-              added new features for prospective and existing members to add to
-              their profile.{" "}
+              <strong>More filter functionality coming soon!</strong> New
+              features were recently added for prospective and existing members
+              to add to their profile. If you're on the list,{" "}
+              <Link href="/edit">add them now</Link>!
             </BannerAlert>
             <div style={{ marginTop: "1rem" }}>
               <MoreOptions />

--- a/components/FocusPicker.tsx
+++ b/components/FocusPicker.tsx
@@ -57,7 +57,6 @@ export default function FocusPicker({
             ref={listRef}
             style={{
               maxHeight: menuExpanded ? defaultHeight : minimizedHeight,
-              overflow: "hidden",
             }}
           >
             <li className="picker__item" ref={listItemRef}>
@@ -133,6 +132,7 @@ export default function FocusPicker({
             gap: 0.5rem;
             flex-wrap: wrap;
             transition: 150ms ease-out max-height;
+            overflow: hidden;
           }
           .picker__item {
             margin: 0;


### PR DESCRIPTION
A side of effect of getting an influx of updates/new additions after the update is that we have **too many filters** being shown in a single view.

This PR:
- Makes sure that we only display 2 rows at a given time
- Animates the drawer transition a little more elegantly.