### PR TITLE
updated email subject(s)

### DIFF
--- a/lib/email/confirmation-email.ts
+++ b/lib/email/confirmation-email.ts
@@ -66,7 +66,7 @@ export async function sendConfirmationEmails({
       email: REPLY_EMAIL,
       name: "Hawaiians in Tech",
     },
-    subject: `New Submission`,
+    subject: `New Submission: ${name}`,
     html: emailTemplate2,
   });
 }

--- a/lib/email/request-update-email.ts
+++ b/lib/email/request-update-email.ts
@@ -55,7 +55,9 @@ export async function sendRequestUpdateEmail({
       email: REPLY_EMAIL,
       name: "Hawaiians in Tech",
     },
-    subject: `New Request`,
+    subject: `${
+      removeRequest ? "💔 Removal requested from" : "✨ Change requested from"
+    } ${name}`,
     html: emailTemplate,
   });
 }


### PR DESCRIPTION
Adjusted email subject lines so that they are unique per member. Should help separate emails into unique threads in inbox.

<img width="847" alt="image" src="https://user-images.githubusercontent.com/5141111/170182216-41c571d3-43bd-4ed4-b015-0a1f62f4177c.png">

Test case:
- [ ] Create new member in **Join** flow
- [ ] Confirm email subject line contains member name (sent to kamakani@hawaiiansintech.org and taylor@hawaiiansintech.org)
- [ ] Create another member
- [ ] Confirm email is not merged with the same thread like before
- [ ] Repeat for **Request Changes** if desired