### PR TITLE
Updating top nav order

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -40,13 +40,12 @@ export default function Nav({
               <Link href="/about">
                 <a className="nav-link">About</a>
               </Link>
-              <Link href="/edit">
-                <a className="nav-link">Request Changes</a>
-              </Link>
               <Link href="/join/01-you">
                 <a className="primary-link">Join the list</a>
               </Link>
-
+              <Link href="/edit">
+                <a className="nav-link">Request Changes</a>
+              </Link>
               <Link href="/hackathon">
                 <a className="hackathon-link">Hackathon</a>
               </Link>


### PR DESCRIPTION
Updating the order of the navigation links
- Shifting the `Join the List` CTA to give it higher priority.
- Decided not to move the `Hackathon` link since we generally want to keep it paired with the `Request Changes` link.

**Current:**
<img width="599" alt="Screen Shot 2022-07-04 at 5 38 13 PM" src="https://user-images.githubusercontent.com/5141111/177228855-818378a0-7489-4d73-a3f6-220572c49a42.png">

**Proposed:**
<img width="611" alt="image" src="https://user-images.githubusercontent.com/5141111/177228755-f348fb3b-31e8-4175-9ca1-df2f3d26cb03.png">
