### PR TITLE
update "anything else" translation

### DIFF
--- a/pages/edit/04-contact.tsx
+++ b/pages/edit/04-contact.tsx
@@ -197,7 +197,7 @@ export default function JoinStep4({ pageTitle }) {
               <Input
                 name="other"
                 label="Anything else?"
-                labelTranslation="He aha nā mea a pau?"
+                labelTranslation="He mau manaʻo hou aku kou?"
                 onBlur={props.handleBlur}
                 value={other}
                 onChange={(e) => setOther(e.target.value)}


### PR DESCRIPTION
Got feedback to adjust the copy for "anything else" in a member's change request.